### PR TITLE
Addressed two issues in tuple benchmarks

### DIFF
--- a/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/BenchmarkingTest.scala
+++ b/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/BenchmarkingTest.scala
@@ -2,6 +2,10 @@ package miniboxing.benchmarks.tuples.launch
 
 import scalameter._
 import tests._
+import miniboxing.runtime.MiniboxedTuple
+import miniboxing.runtime.MiniboxConstants
+import miniboxing.runtime.MiniboxConversions
+import miniboxing.runtime.MiniboxConversionsDouble
 
 object BenchmarkingTest extends ScalameterBenchTest
                            with GenericBenchTest
@@ -21,15 +25,28 @@ object BenchmarkingTest extends ScalameterBenchTest
 
   // the test size
   lazy val testSizes = {
-    List(3000000)
+    List(1000000)
   }
-  
-  withTestSize(3000000){
-    // run the tests:    
-    testHardcodedMiniboxed()
-    testMiniboxed()
-    testIdeal()
-    testGeneric()
-    testSpecialized()
+
+  withTestSize(1000000){
+    var arr: Array[(Int, Double)] = new Array[(Int, Double)](testSize)
+    val random = new util.Random(0)
+    for( ind <- 0 to (testSize - 1)){
+      arr(ind) = (random.nextInt(testSize), 0.0)
+//      // alternative approach, should produce the same result:
+//      arr(ind) = MiniboxedTuple.newTuple2_long_double[Int, Double](
+//        MiniboxConstants.INT,
+//        MiniboxConstants.DOUBLE,
+//        MiniboxConversions.int2minibox(random.nextInt(testSize)),
+//        MiniboxConversionsDouble.double2minibox(0.0)
+//      )
+    }
+
+    // run the tests:
+    testHardcodedMiniboxed(arr)
+    testMiniboxed(arr)
+    testIdeal(arr)
+    testGeneric(arr)
+    testSpecialized(arr)
   }
 }

--- a/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/GenericBenchTest.scala
+++ b/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/GenericBenchTest.scala
@@ -4,14 +4,8 @@ import miniboxing.benchmarks.tuples.generic.TuplesQuickSort
 import scala.util.Random
 
 trait GenericBenchTest extends BaseTest {
-  
-  def testGeneric() = {
-    var arr: Array[(Int, Double)] = new Array[(Int, Double)](testSize)
-    val random = new Random(0)
-    for( ind <- 0 to (testSize - 1)){
-       arr(ind) = (random.nextInt(testSize), 0.0)
-    }
 
-    test("generic", "quicksort_array_of_tuples", _ => (), TuplesQuickSort.quicksortByKey[Int](arr), () => {})
+  def testGeneric(arr: Array[(Int, Double)]) = {
+    test("generic", "quicksort_array_of_tuples", _ => (), TuplesQuickSort.quicksortByKey[Int](arr.clone()), () => {})
   }
 }

--- a/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/HardcodedMiniboxedBenchTest.scala
+++ b/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/HardcodedMiniboxedBenchTest.scala
@@ -9,24 +9,13 @@ import miniboxing.runtime.MiniboxConversionsDouble
 import miniboxing.runtime.MiniboxedTuple
 
 trait HardcodedMiniboxedBenchTest extends BaseTest {
-  
-  def testHardcodedMiniboxed() = {
-    var arr: Array[(Int, Double)] = new Array[(Int, Double)](testSize)
-    val random = new Random(0)
-    for( ind <- 0 to (testSize - 1)){
-      arr(ind) = MiniboxedTuple.newTuple2_long_double[Int, Double](
-        MiniboxConstants.INT,
-        MiniboxConstants.DOUBLE,
-        MiniboxConversions.int2minibox(random.nextInt(testSize)),
-        MiniboxConversionsDouble.double2minibox(0.0)
-      )
-    }
 
+  def testHardcodedMiniboxed(arr: Array[(Int, Double)]) = {
     test(
-      "miniboxed_hardcoded-" + arr.length, 
-      "quicksort_array_of_tuples", 
-      _ => (),  
-      TuplesQuickSort.quicksortByKeyLong[Int](arr)(TuplesQuickSort.IntMiniboxedOrdering), 
+      "miniboxed_hardcoded-" + arr.length,
+      "quicksort_array_of_tuples",
+      _ => (),
+      TuplesQuickSort.quicksortByKeyLong[Int](arr.clone())(TuplesQuickSort.IntMiniboxedOrdering),
       () => {}
     )
   }

--- a/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/IdealBenchTest.scala
+++ b/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/IdealBenchTest.scala
@@ -4,19 +4,13 @@ import miniboxing.benchmarks.tuples.ideal.TuplesQuickSort
 import scala.util.Random
 
 trait IdealBenchTest extends BaseTest {
-  
-  def testIdeal() = {
-    var arr: Array[(Int, Double)] = new Array[(Int, Double)](testSize)
-    val random = new Random(0)
-    for( ind <- 0 to (testSize - 1)){
-       arr(ind) = (random.nextInt(testSize), 0.0)
-    }
 
+  def testIdeal(arr: Array[(Int, Double)]) = {
     test(
-      "ideal", 
-      "quicksort_array_of_tuples", 
-      _ => (),  
-      TuplesQuickSort.quicksortByKey(arr)(TuplesQuickSort.IntIdealOrdering), 
+      "ideal",
+      "quicksort_array_of_tuples",
+      _ => (),
+      TuplesQuickSort.quicksortByKey(arr.clone())(TuplesQuickSort.IntIdealOrdering),
       () => {}
      )
   }

--- a/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/MiniboxedBenchTest.scala
+++ b/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/MiniboxedBenchTest.scala
@@ -4,19 +4,13 @@ import scala.util.Random
 import miniboxing.benchmarks.tuples.miniboxed.TuplesQuickSort
 
 trait MiniboxedBenchTest extends BaseTest {
-  
-  def testMiniboxed() = {
-    var arr: Array[(Int, Double)] = new Array[(Int, Double)](testSize)
-    val random = new Random(0)
-    for( ind <- 0 to (testSize - 1)){
-       arr(ind) = (random.nextInt(testSize), 0.0)
-    }
 
+  def testMiniboxed(arr: Array[(Int, Double)]) = {
     test(
-      "miniboxed", 
-      "quicksort_array_of_tuples", 
-      _ => (),  
-      TuplesQuickSort.quicksortByKey[Int](arr)(TuplesQuickSort.IntMiniboxedOrdering), 
+      "miniboxed",
+      "quicksort_array_of_tuples",
+      _ => (),
+      TuplesQuickSort.quicksortByKey[Int](arr.clone())(TuplesQuickSort.IntMiniboxedOrdering),
       () => {}
     )
   }

--- a/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/SpecializedBenchTest.scala
+++ b/tests/lib-bench/src/miniboxing/benchmarks/tuples/launch/tests/SpecializedBenchTest.scala
@@ -4,19 +4,13 @@ import miniboxing.benchmarks.tuples.specialized.TuplesQuickSort
 import scala.util.Random
 
 trait SpecializedBenchTest extends BaseTest {
-  
-  def testSpecialized() = {
-    var arr: Array[(Int, Double)] = new Array[(Int, Double)](testSize)
-    val random = new Random(0)
-    for( ind <- 0 to (testSize - 1)){
-       arr(ind) = (random.nextInt(testSize), 0.0)
-    }
 
+  def testSpecialized(arr: Array[(Int, Double)]) = {
     test(
-      "specialized", 
-      "quicksort_array_of_tuples", 
-      _ => (),  
-      TuplesQuickSort.quicksortByKey[Int](arr)(TuplesQuickSort.IntSpecializedOrdering), 
+      "specialized",
+      "quicksort_array_of_tuples",
+      _ => (),
+      TuplesQuickSort.quicksortByKey(arr.clone())(TuplesQuickSort.IntSpecializedOrdering),
       () => {}
      )
   }

--- a/tests/lib-bench/src/miniboxing/benchmarks/tuples/specialized/TuplesQuickSort.scala
+++ b/tests/lib-bench/src/miniboxing/benchmarks/tuples/specialized/TuplesQuickSort.scala
@@ -1,19 +1,19 @@
 package miniboxing.benchmarks.tuples.specialized
 
 object TuplesQuickSort {
-  
-  trait SpecializedOrdering[@specialized T] {
+
+  trait SpecializedOrdering[@specialized(Int) T] {
     def compare(t1: T, t2: T): Int
     def lt(t1: T, t2: T): Boolean = compare(t1, t2) < 0
     def gt(t1: T, t2: T): Boolean = compare(t1, t2) > 0
     def eq(t1: T, t2: T): Boolean = compare(t1, t2) == 0
   }
-  
+
   object IntSpecializedOrdering extends SpecializedOrdering[Int] {
     override def compare(t1: Int, t2: Int): Int = t1 - t2
   }
-  
-  private def quicksort[@specialized T](a:Array[(T, Double)])(ord: SpecializedOrdering[T]): Array[(T, Double)] =  {
+
+  private def quicksort[@specialized(Int) T](a:Array[(T, Double)])(ord: SpecializedOrdering[T]): Array[(T, Double)] =  {
     def swap(i: Int, j: Int): Unit = {
       val t = a(i); a(i) = a(j); a(j) = t
     }
@@ -35,7 +35,11 @@ object TuplesQuickSort {
     partition(0, a.length - 1)
     a
   }
-  
-  def quicksortByKey[@specialized T](arr: Array[(T, Double)])(ord: SpecializedOrdering[T]): Array[(T, Double)] =
-    quicksort(arr)(ord)
+
+// specialization doesn't rewire the call to quicksort correctly:
+//  def quicksortByKey[@specialized(Int) T](arr: Array[(T, Double)])(ord: SpecializedOrdering[T]): Array[(T, Double)] =
+//    quicksort[T](arr)(ord)
+
+  def quicksortByKey(arr: Array[(Int, Double)])(ord: SpecializedOrdering[Int]): Array[(Int, Double)] =
+    quicksort[Int](arr)(ord)
 }


### PR DESCRIPTION
1. The array was only sorted once (the first time), then it was just traversed
   -- added calls to `clone` to make sure we traverse the same array in all tests
   and that each test run gets a fresh clone
2. Specialization didn't rewire a method correctly
   (https://issues.scala-lang.org/browse/SI-9263)
